### PR TITLE
docs: mark project decommissioned 2026-05-14 + bring-back recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,26 @@
 # MLX Distributed Ring Inference — Project Context
 
+## ⏸️ DECOMMISSIONED 2026-05-14 — bridge dismantled, not currently runnable
+
+The mini1↔mini2 Thunderbolt Bridge that this project runs over has been **physically
+disconnected** (cables pulled by the user 2026-05-14). Reason: LLM inference now runs on
+**pgx** (NVIDIA GB10), so the 2×M4 distributed ring is no longer needed. Nothing here is
+broken — it is intentionally idle.
+
+**Why it was pulled:** the bridge had *multiple* Thunderbolt cables between the two minis,
+all enslaved to `bridge0` with macOS STP not arbitrating → a layer-2 loop → ~196k pkt/s
+broadcast storm that pinned `mDNSResponder`/`netbiosd` and drove load to ~11 on both minis.
+
+### To bring it back
+1. **Reconnect exactly ONE Thunderbolt cable** between mini1 and mini2 — **not two**.
+   Two cables both in `bridge0` re-creates the broadcast-storm loop. If you must have
+   redundancy, enable STP on `bridge0` properly first.
+2. `bridge0` re-acquires link; `192.168.5.1` (mini1) / `192.168.5.2` (mini2) come back
+   (verify: `ifconfig bridge0`). `launch.sh` detects the machine off these IPs.
+3. `./launch.sh start` from this dir on either mini.
+4. `netbiosd` is disabled on both minis (unrelated cleanup, 2026-05-14) — leave it disabled;
+   the ring does not need it.
+
 ## Current State (2026-02-22)
 
 The distributed ring is **working** with:


### PR DESCRIPTION
## Summary
- mini1↔mini2 Thunderbolt bridge was physically disconnected 2026-05-14 (cables pulled). Reason: LLM inference now runs on pgx (NVIDIA GB10) so the 2×M4 distributed ring is no longer needed.
- Nothing is broken — the project is intentionally idle.
- Adds a "to bring it back" recipe at the top of `CLAUDE.md` so a future session does not waste time on diagnostics or re-creating the broadcast-storm loop (two cables enslaved to `bridge0` without macOS STP → ~196k pkt/s loop that pinned mDNSResponder/netbiosd).

Cross-reference: memory record `mini1-mini2-thunderbolt-bridge-loop.md`.

## Test plan
- [x] Markdown-only change; pre-commit (ruff + ty) passed
- [x] No code, no CI surface affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)